### PR TITLE
Add Lib zeppos-timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@
 - [numeric-keyboard-amazfit-devices](https://github.com/Rafucho25/numeric-keyboard-amazfit-devices) - A simple numeric keyboard for amazfit band 7, GTS 4, GTS 4 mini and GTS 3.
 - [Authenticator](https://github.com/ZoLArk173/Authenticator) - An 2FA app for Zepp OS.
 - [zeppos-fx](https://github.com/XiaomaiTX/zeppos-fx) - A library for providing simple animations in ZeppOS.
+- [zeppos-timer](https://github.com/XiaomaiTX/zeppos-timer) - An accurate timer for ZeppOS.
 
 ### Tool
 - [zepp-ts](https://github.com/tytydraco/zepp-ts) - Build tool that use typescript to develop zeppos-app.


### PR DESCRIPTION
An accurate timer for ZeppOS. 
ZeppTimer is a small and refined JavaScript class that provides an accurate timer for the ZeppOS system.


Here's why:

- In all versions of ZeppOS, there is a significant time discrepancy between the system's timer and the actual time due to underlying issues with the system. To achieve more accurate timing, I implemented a simple but effective approach to reduce timing errors and packaged it into ZeppTimer. 

- Furthermore, in ZeppOS 2.x, the official approach to timer components was replaced with setTimeOut and cleanTimeOut, requiring logic adjustments when migrating ZeppOS 1.0 applications that use timers to ZeppOS 2.x and above. Using the ZeppTimer library can save developers the cost of migration.