### PR TITLE
Add App FediClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@
 - [BTC-ZeppOS-for-Watch](https://github.com/fwz233/BTC-ZeppOS-for-Watch) - Check btc price at the moment on a watch running Zepp OS.
 - [zhihu](https://github.com/fwz233/zhihu) - See the hot list of Zhihu on the zeppos device.
 
+### Social Media
+
+- [FediClient](https://github.com/griffi-gh/zepp-fediclient) - Open-source Mastodon client for ZeppOS.
+
 ### Music
 
 - [ZeppOS-Spotify](https://github.com/juan518munoz/ZeppOS-Spotify/) - Spotify manager for ZeppOS.


### PR DESCRIPTION
Application repository: https://github.com/griffi-gh/zepp-fediclient
I also added a "Social Media" category as I don't believe it fits into any existing category.

Open-source mastodon client for ZeppOS.
The app is still in development and I'm planning to release it on Zepp App Store eventually.

Also, I'm planning to eventually separate out the image loading part of the client into a library for all ZeppOS developers to use. The dynamic image loader converts images to the TGA format on-the-fly (handling things like quantization automatically), delivers image data efficiently, caches files on the watch to speed up loading, and operates fully asynchronously.

Features of the app:
- Supports Mastodon (or Sharkey) servers, with Misskey support planned.
- Viewing timelines (Local/Public/Home)
- Viewing posts/post replies
- Profile pictures (dynamically generated tga; loaded asynchronously)
- Viewing post image attachments (experimental)
- Viewing user profiles
- Posting (with a t-9 style keyboard)
- Authentication (optional, using OAuth)
- Localization 
  - (currently supports English, Polish and Ukrainian)
  

